### PR TITLE
Deferred copy trouble on Node v0.8

### DIFF
--- a/lib/misc.js
+++ b/lib/misc.js
@@ -18,7 +18,13 @@ exports.copy = function(src, dest) {
   read.on('error', deferred.reject);
 
   var write = fs.createWriteStream(dest, {flags: 'wx'});
-  write.on('error', deferred.reject);
+  write.on('error', function(err) {
+    // rejecting immediately was causing trouble on Node v0.8
+    // see https://github.com/tschaub/get-down/issues/1
+    process.nextTick(function() {
+      deferred.reject(err);
+    });
+  });
   write.on('close', deferred.resolve.bind(deferred, dest));
 
   read.pipe(write);


### PR DESCRIPTION
There are [periodic test failures](https://travis-ci.org/tschaub/get-down/jobs/16537742) on Node v0.8 that only occur when testing a rejected `misc.copy` promise.

This looks like an unhandled error in the `oncomplete` method for a socket's write request: 

```
     Uncaught Error: write EBADF
      at errnoException (net.js:770:11)
      at Object.afterWrite (net.js:594:19)
```
